### PR TITLE
Add oil returns summary page for administrators

### DIFF
--- a/controllers/OilReturnsSummaryController.php
+++ b/controllers/OilReturnsSummaryController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace app\controllers;
+
+use Yii;
+use app\models\OilInventory;
+use app\models\Stores;
+use app\models\User;
+use yii\web\Controller;
+use yii\filters\AccessControl;
+use app\components\AccessRule;
+use yii\db\Query;
+
+class OilReturnsSummaryController extends Controller
+{
+    public function behaviors()
+    {
+        return [
+            'access' => [
+                'class' => AccessControl::class,
+                'only' => ['*'],
+                'ruleConfig' => [
+                    'class' => AccessRule::class,
+                ],
+                'rules' => [
+                    [
+                        'actions' => ['index'],
+                        'allow' => true,
+                        'roles' => [
+                            User::ROLE_ADMIN,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function actionIndex()
+    {
+        $dateFrom = Yii::$app->request->get('date_from', date('Y-m-d', strtotime('-7 days')));
+        $dateTo = Yii::$app->request->get('date_to', date('Y-m-d'));
+
+        $query = (new Query())
+            ->select([
+                's.name as terminal_name',
+                's.id as store_id',
+                'SUM(oi.return_amount_kg) as total_return_kg',
+                'SUM(oi.return_amount) as total_return_liters'
+            ])
+            ->from(['oi' => OilInventory::tableName()])
+            ->leftJoin(['s' => Stores::tableName()], 's.id = oi.store_id')
+            ->where(['between', 'DATE(oi.created_at)', $dateFrom, $dateTo])
+            ->andWhere(['oi.status' => OilInventory::STATUS_ACCEPTED])
+            ->groupBy(['s.id', 's.name'])
+            ->orderBy(['s.name' => SORT_ASC]);
+
+        $data = $query->all();
+
+        $totalReturnKg = array_sum(array_column($data, 'total_return_kg'));
+        $totalReturnLiters = array_sum(array_column($data, 'total_return_liters'));
+
+        return $this->render('index', [
+            'data' => $data,
+            'dateFrom' => $dateFrom,
+            'dateTo' => $dateTo,
+            'totalReturnKg' => $totalReturnKg,
+            'totalReturnLiters' => $totalReturnLiters,
+        ]);
+    }
+}

--- a/views/menu/admin.php
+++ b/views/menu/admin.php
@@ -48,6 +48,7 @@ use yii\helpers\Html;
             <li><?= Html::a('Пользователи', ['user/index']) ?></li>
             <li><?= Html::a('Telegram Пользователи', ['tgusers/index']) ?></li>
             <li><?= Html::a('Приём масла', ['/oil-inventory/filled']) ?></li>
+            <li><?= Html::a('Сводка возврата масла', ['/oil-returns-summary/index']) ?></li>
             <li><?= Html::a('Списания', ['write-offs/index']) ?></li>
             <li><?= Html::a('Привязка товаров', ['products/links']) ?></li>
             <li><?= Html::a('Настройки', ['settings/index']) ?></li>

--- a/views/oil-returns-summary/index.php
+++ b/views/oil-returns-summary/index.php
@@ -1,0 +1,107 @@
+<?php
+
+use yii\helpers\Html;
+use yii\widgets\ActiveForm;
+use kartik\date\DatePicker;
+
+$this->title = 'Сводка возврата масла по филиалам';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="oil-returns-summary-index">
+
+    <h1><?= Html::encode($this->title) ?></h1>
+
+    <div class="well">
+        <?php $form = ActiveForm::begin(['method' => 'get']); ?>
+        
+        <div class="row">
+            <div class="col-md-4">
+                <?= DatePicker::widget([
+                    'name' => 'date_from',
+                    'value' => $dateFrom,
+                    'type' => DatePicker::TYPE_INPUT,
+                    'pluginOptions' => [
+                        'autoclose' => true,
+                        'format' => 'yyyy-mm-dd',
+                        'todayHighlight' => true,
+                    ],
+                    'options' => [
+                        'placeholder' => 'Дата с',
+                    ]
+                ]); ?>
+            </div>
+            
+            <div class="col-md-4">
+                <?= DatePicker::widget([
+                    'name' => 'date_to',
+                    'value' => $dateTo,
+                    'type' => DatePicker::TYPE_INPUT,
+                    'pluginOptions' => [
+                        'autoclose' => true,
+                        'format' => 'yyyy-mm-dd',
+                        'todayHighlight' => true,
+                    ],
+                    'options' => [
+                        'placeholder' => 'Дата по',
+                    ]
+                ]); ?>
+            </div>
+            
+            <div class="col-md-4">
+                <?= Html::submitButton('Применить фильтр', ['class' => 'btn btn-primary']) ?>
+                <?= Html::a('Сбросить', ['index'], ['class' => 'btn btn-default']) ?>
+            </div>
+        </div>
+        
+        <?php ActiveForm::end(); ?>
+    </div>
+
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">
+                Период: <?= Yii::$app->formatter->asDate($dateFrom, 'long') ?> - <?= Yii::$app->formatter->asDate($dateTo, 'long') ?>
+            </h3>
+        </div>
+        <div class="panel-body">
+            <table class="table table-striped table-bordered">
+                <thead>
+                    <tr>
+                        <th>Филиал</th>
+                        <th>Сумма возврата масла (кг)</th>
+                        <th>Сумма возврата масла (л)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if (!empty($data)): ?>
+                        <?php foreach ($data as $row): ?>
+                            <tr>
+                                <td><?= Html::encode($row['terminal_name'] ?: 'Без названия') ?></td>
+                                <td class="text-right">
+                                    <strong><?= Yii::$app->formatter->asDecimal($row['total_return_kg'], 2) ?> кг</strong>
+                                </td>
+                                <td class="text-right">
+                                    <?= Yii::$app->formatter->asDecimal($row['total_return_liters'], 2) ?> л
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                        <tr class="info">
+                            <td><strong>Итого:</strong></td>
+                            <td class="text-right">
+                                <strong><?= Yii::$app->formatter->asDecimal($totalReturnKg, 2) ?> кг</strong>
+                            </td>
+                            <td class="text-right">
+                                <strong><?= Yii::$app->formatter->asDecimal($totalReturnLiters, 2) ?> л</strong>
+                            </td>
+                        </tr>
+                    <?php else: ?>
+                        <tr>
+                            <td colspan="3" class="text-center">Нет данных за выбранный период</td>
+                        </tr>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+</div>


### PR DESCRIPTION
## Summary
- Added a new oil returns summary page accessible only to administrators
- Displays aggregated oil return data grouped by terminal/branch
- Includes date range filtering functionality

## Changes
- Created `OilReturnsSummaryController` with admin-only access control
- Added summary view with date picker for filtering by date range
- Displays oil returns in both kilograms (primary) and liters
- Only includes accepted oil return records in calculations
- Added navigation link in admin menu under "Other" dropdown

## Test plan
- [x] Verify page is only accessible to administrators
- [x] Test date range filtering functionality
- [x] Confirm data is correctly grouped by terminal
- [x] Validate that only accepted returns are included in totals
- [ ] Test with various date ranges and data scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)